### PR TITLE
feature: clean on exit for Air

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -40,7 +40,7 @@ silent = false
 time = false
 
 [misc]
-clean_on_exit = false
+clean_on_exit = true
 
 [proxy]
 app_port = 0


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `clean_on_exit` to `true` in `.air.toml` to enable cleanup on application exit.
> 
>   - **Configuration**:
>     - Set `clean_on_exit` to `true` in `.air.toml` to enable cleanup on application exit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=yz778%2Fllmsee&utm_source=github&utm_medium=referral)<sup> for f5db22c494b1f8ef667e763fdd1dcf330601731e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->