### PR TITLE
fix: handle empty provider and model in proxy request

### DIFF
--- a/handler_proxy.go
+++ b/handler_proxy.go
@@ -396,6 +396,10 @@ func (s *ProxyServer) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// for /v1 requests, extract the provider and model name
 	if v1Request {
 		parts := strings.SplitN(model, ":", 2) // <provider>:<model>
+		if len(parts) < 2 {
+			http.Error(w, `{"error":"Failed to identify provider and model, this is an empty request"}`, http.StatusNotFound)
+			return
+		}
 		provider = parts[0]
 		model = parts[1]
 		bodyJSON["model"] = model


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add check for empty provider and model in `handleProxy()` to return 404 error for malformed `/v1` requests.
> 
>   - **Behavior**:
>     - In `handleProxy()` in `handler_proxy.go`, added a check for empty provider and model in `/v1` requests.
>     - Returns a 404 error with message "Failed to identify provider and model, this is an empty request" if the model string is not in the expected format `<provider>:<model>`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=yz778%2Fllmsee&utm_source=github&utm_medium=referral)<sup> for 73000503989574b3998683095d4a5ffd9ebab240. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->